### PR TITLE
Add notebook to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ pip install pandas numpy torch
 2. `20200923 Pytorch_Titanic.ipynb` を Jupyter Notebook で開きます。
 3. セルを順に実行してモデルを学習・評価します。
 
+## テスト
+
+`pytest` コマンドで単体テストを実行できます。
+Jupyter 上で結果を確認したい場合は `run_tests.ipynb` を開いてセルを実行してください。
+
 ## 参考
 
 このノートブックは次の記事を参考にしています:

--- a/net.py
+++ b/net.py
@@ -1,0 +1,15 @@
+import torch.nn as nn
+import torch.nn.functional as F
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.fc1 = nn.Linear(4, 20)
+        self.fc2 = nn.Linear(20, 10)
+        self.fc3 = nn.Linear(10, 2)
+
+    def forward(self, x):
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = F.relu(self.fc3(x))
+        return F.log_softmax(x, dim=1)

--- a/run_tests.ipynb
+++ b/run_tests.ipynb
@@ -1,0 +1,32 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run Tests"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "!pytest -q",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+import torch
+
+# Ensure project root is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from net import Net
+
+
+def test_forward_shape():
+    model = Net()
+    x = torch.randn(1, 4)
+    output = model(x)
+    assert output.shape == (1, 2)


### PR DESCRIPTION
## Summary
- add a simple Jupyter notebook `run_tests.ipynb` with a cell to run pytest
- document how to execute tests in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683faa2ae58c8326857fd6873a72a829