### PR TITLE
Add static demo web UI and README instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+.dist-info/
+
+# Virtual environments
+.venv/
+venv/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Data and outputs
+data/
+outputs/
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 このリポジトリは、Kaggle の Titanic データセットを用いて PyTorch でニューラルネットワークを学習する例を提供します。
 
+## リポジトリ構成
+
+- `20200923 Pytorch_Titanic.ipynb`: 学習用ノートブック
+- `src/titanic`: パッケージの足場 (CLI など拡張用)
+- `notebooks/`: 追加ノートブック置き場
+- `data/`: データセット置き場 (Git 管理外)
+- `webapp/`: デモ UI (HTML/CSS/JS)
+
 ## 必要条件
 
 - Python 3
@@ -12,7 +20,7 @@
 依存関係は次のコマンドでインストールできます:
 
 ```bash
-pip install pandas numpy torch
+pip install -r requirements.txt
 ```
 
 ## 使い方
@@ -20,6 +28,22 @@ pip install pandas numpy torch
 1. Kaggle から Titanic データセットをダウンロードします。
 2. `20200923 Pytorch_Titanic.ipynb` を Jupyter Notebook で開きます。
 3. セルを順に実行してモデルを学習・評価します。
+
+CLI の雛形を確認する場合は次を実行します:
+
+```bash
+python -m titanic
+```
+
+## デモアプリ
+
+簡易的な生存予測 UI をブラウザで確認できます:
+
+```bash
+python -m http.server 8000 --directory webapp
+```
+
+ブラウザで `http://localhost:8000` を開くと、デモ画面が表示されます。
 
 ## 参考
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pandas
+torch
+jupyter

--- a/src/titanic/__init__.py
+++ b/src/titanic/__init__.py
@@ -1,0 +1,4 @@
+"""PyTorch Titanic starter package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/src/titanic/__main__.py
+++ b/src/titanic/__main__.py
@@ -1,0 +1,21 @@
+"""Command-line entry point for the project."""
+
+from __future__ import annotations
+
+import textwrap
+
+
+def main() -> None:
+    message = """
+    PyTorch Titanic repository scaffold
+
+    This project currently focuses on the notebook workflow. To get started:
+      1) Install dependencies from requirements.txt
+      2) Download the Kaggle Titanic dataset
+      3) Open the notebook in notebooks/ or the repository root
+    """
+    print(textwrap.dedent(message).strip())
+
+
+if __name__ == "__main__":
+    main()

--- a/webapp/app.js
+++ b/webapp/app.js
@@ -1,0 +1,61 @@
+const form = document.getElementById("predict-form");
+const scoreValue = document.getElementById("score");
+const scoreCaption = document.getElementById("score-caption");
+
+const coefficients = {
+  intercept: -0.5,
+  female: 1.2,
+  age: -0.03,
+  pclass1: 0.8,
+  pclass2: 0.4,
+  fare: 0.02,
+  sibsp: -0.1,
+  parch: -0.08,
+};
+
+function sigmoid(value) {
+  return 1 / (1 + Math.exp(-value));
+}
+
+function computeScore() {
+  const sex = document.getElementById("sex").value;
+  const age = Number(document.getElementById("age").value || 0);
+  const pclass = Number(document.getElementById("pclass").value || 3);
+  const fare = Number(document.getElementById("fare").value || 0);
+  const sibsp = Number(document.getElementById("sibsp").value || 0);
+  const parch = Number(document.getElementById("parch").value || 0);
+
+  let score = coefficients.intercept;
+  if (sex === "female") {
+    score += coefficients.female;
+  }
+  score += coefficients.age * age;
+  score += coefficients.fare * Math.log1p(fare);
+  score += coefficients.sibsp * sibsp;
+  score += coefficients.parch * parch;
+
+  if (pclass === 1) {
+    score += coefficients.pclass1;
+  } else if (pclass === 2) {
+    score += coefficients.pclass2;
+  }
+
+  const probability = sigmoid(score);
+  const percent = (probability * 100).toFixed(2);
+  scoreValue.textContent = percent;
+
+  let caption = "平均的なスコアです";
+  if (probability > 0.7) {
+    caption = "生存確率が高めのシナリオ";
+  } else if (probability < 0.3) {
+    caption = "生存確率が低めのシナリオ";
+  }
+  scoreCaption.textContent = caption;
+}
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  computeScore();
+});
+
+computeScore();

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PyTorch Titanic デモ</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="hero">
+        <div>
+          <p class="eyebrow">PyTorch Titanic</p>
+          <h1>生存予測デモ</h1>
+          <p class="lead">
+            こちらは学習済みモデルの代わりに、簡易的なルールベース係数でスコアを計算するデモです。
+            実データで学習したモデルはノートブックから生成してください。
+          </p>
+        </div>
+        <div class="score-card" id="score-card">
+          <p class="score-label">予測スコア</p>
+          <p class="score-value" id="score">0.00</p>
+          <p class="score-caption" id="score-caption">入力値を調整してください</p>
+        </div>
+      </header>
+
+      <section class="panel">
+        <h2>入力パラメータ</h2>
+        <form id="predict-form" class="form-grid">
+          <label>
+            性別
+            <select name="sex" id="sex">
+              <option value="female">女性</option>
+              <option value="male">男性</option>
+            </select>
+          </label>
+          <label>
+            年齢
+            <input type="number" name="age" id="age" min="0" max="80" value="29" />
+          </label>
+          <label>
+            乗船クラス
+            <select name="pclass" id="pclass">
+              <option value="1">1等</option>
+              <option value="2">2等</option>
+              <option value="3" selected>3等</option>
+            </select>
+          </label>
+          <label>
+            料金
+            <input type="number" name="fare" id="fare" min="0" step="0.1" value="13.0" />
+          </label>
+          <label>
+            同乗兄弟・配偶者数
+            <input type="number" name="sibsp" id="sibsp" min="0" max="8" value="0" />
+          </label>
+          <label>
+            同乗親・子供数
+            <input type="number" name="parch" id="parch" min="0" max="6" value="0" />
+          </label>
+          <button type="submit" class="primary">スコア更新</button>
+        </form>
+      </section>
+
+      <section class="panel">
+        <h2>簡易モデルの仕組み</h2>
+        <ul class="list">
+          <li>女性・上位クラスほどスコアが上昇するように係数を設定しています。</li>
+          <li>年齢・同乗家族数はスコアに緩やかな影響を与えます。</li>
+          <li>このスコアはデモ用途のため、実際の生存確率とは異なります。</li>
+        </ul>
+      </section>
+    </main>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -1,0 +1,142 @@
+:root {
+  color-scheme: light;
+  font-family: "Noto Sans JP", "Hiragino Kaku Gothic Pro", sans-serif;
+  line-height: 1.6;
+  --bg: #f6f7fb;
+  --panel: #ffffff;
+  --accent: #1f4fff;
+  --text: #1b1f2a;
+  --muted: #6b7280;
+  --border: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  padding: 32px;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  background: var(--panel);
+  padding: 28px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.2em;
+  color: var(--muted);
+  margin-bottom: 12px;
+}
+
+.lead {
+  color: var(--muted);
+  margin-top: 12px;
+}
+
+.score-card {
+  min-width: 200px;
+  background: linear-gradient(135deg, #dbeafe, #eff6ff);
+  padding: 20px;
+  border-radius: 16px;
+  text-align: center;
+  border: 1px solid #c7d2fe;
+}
+
+.score-label {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.score-value {
+  font-size: 40px;
+  font-weight: 700;
+  color: var(--accent);
+  margin: 8px 0;
+}
+
+.score-caption {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-top: 16px;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+  font-size: 14px;
+}
+
+input,
+select {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  font-size: 14px;
+}
+
+.primary {
+  grid-column: 1 / -1;
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 10px;
+  padding: 12px 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(31, 79, 255, 0.2);
+}
+
+.list {
+  display: grid;
+  gap: 8px;
+  padding-left: 18px;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 16px;
+  }
+
+  .hero {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a quick, local way to explore a simple Titanic survival demo without running the training notebook. 
- Make it easy to preview model behavior and demonstrate inputs/outputs for the project. 

### Description
- Add a static browser demo comprised of `webapp/index.html`, `webapp/styles.css`, and `webapp/app.js` that computes a rule-based survival score from user inputs. 
- Update `README.md` to document repository layout and include instructions to run the demo with a local HTTP server using `python -m http.server 8000 --directory webapp`. 

### Testing
- Verified the demo served locally using `python -m http.server 8000 --directory webapp` and captured a page screenshot with a Playwright script which produced `artifacts/titanic-demo.png`, confirming the UI loads and the client-side scoring runs. 
- No unit tests were added or run for this change (static assets only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a863be284832687bbbef6f2b02226)